### PR TITLE
add generator to reduce memory usage

### DIFF
--- a/anonymizer/management/commands/anonymize_data.py
+++ b/anonymizer/management/commands/anonymize_data.py
@@ -41,4 +41,3 @@ class Command(AppCommand):
         for a in anonymizers:
             with transaction.atomic():
                 a().run()
-


### PR DESCRIPTION
when working with large amounts of data django iterator still uses too much memory , added a generator that chunks the queryset, using less memory at the expense of making more db queries.

taken from:
http://stackoverflow.com/questions/4222176/why-is-iterating-through-a-large-django-queryset-consuming-massive-amounts-of-me