### PR TITLE
don't print out while anonymizing

### DIFF
--- a/anonymizer/base.py
+++ b/anonymizer/base.py
@@ -1,6 +1,5 @@
 import decimal
 import random
-import sys
 import six
 
 from collections import defaultdict
@@ -309,8 +308,6 @@ class Anonymizer(object):
 
     def run(self, chunksize=2000, parallel=4):
         self.validate()
-        print '\n' + self.model.__name__
-        sys.stdout.write('.')
 
         chunks = self.get_queryset_chunk_iterator(chunksize)
 
@@ -324,11 +321,8 @@ class Anonymizer(object):
                        for objs in chunks]
             for future in futures:
                 future.get()
-                sys.stdout.write('.')
             pool.close()
             pool.join()
-
-        print ''
 
     def validate(self):
         attributes = self.get_attributes()
@@ -393,6 +387,3 @@ def _run(anonymizer, objs):
             if connection.vendor == 'postgresql':
                 cursor.execute('SET CONSTRAINTS ALL DEFERRED')
             cursor.executemany(query, query_args)
-
-    sys.stdout.write('.')
-    sys.stdout.flush()


### PR DESCRIPTION
This is partly for python3 compatibility, and partly because it seems like something that should be implemented in the management command instead of the library