### PR TITLE
implement similar_varchar

### DIFF
--- a/anonymizer/base.py
+++ b/anonymizer/base.py
@@ -77,17 +77,26 @@ class DjangoFaker(object):
         # bypass chopping from max_length
         return str(uuid4())
 
-    def varchar(self, field=None):
+    def varchar(self, field=None, val=None):
         """
         Returns a chunk of text, of maximum length 'max_length'
         """
-        assert field is not None, "The field parameter must be passed to the 'varchar' method."
-        max_length = field.max_length
+        max_length = getattr(field, 'max_length')
+        if max_length is None:
+            max_length = 255
 
         def source():
-            length = random.choice(range(1, max_length + 1))
+            if val is not None:
+                length = random.randint(1, max_length)
+            else:
+                length = len(val)
+
             return "".join(random.choice(general_chars) for i in xrange(length))
-        return self.get_allowed_value(source, field)
+
+        if field is not None:
+            return self.get_allowed_value(source, field)
+        else:
+            return source()
 
     def simple_pattern(self, pattern, field=None):
         """

--- a/anonymizer/replacers.py
+++ b/anonymizer/replacers.py
@@ -12,7 +12,7 @@ def varchar(anon, obj, field, val):
     """
     Returns random data for a varchar field.
     """
-    return anon.faker.varchar(field=field)
+    return anon.faker.varchar()
 
 
 def bool(anon, obj, field, val):
@@ -212,6 +212,13 @@ def similar_lorem(anon, obj, field, val):
     'yes' or 'no'), this could easily fail to hide the original data.
     """
     return anon.faker.lorem(field=field, val=val)
+
+
+def similar_varchar(anon, obj, field, val):
+    """
+    Returns random data of the same length as val
+    """
+    return anon.faker.similar_varchar(field=field, val=val)
 
 
 def choice(anon, obj, field, val):


### PR DESCRIPTION
When using `varchar` on a field without `max_length`, the `varchar` replacer will throw the following exception:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

This PR makes the following changes:
* `varchar` replacer now returns a string of random characters between [1-255] in length.
* `similar_varchar` replacer returns a string of random characters the same length as the input value