### PR TITLE
Prompt confirmation of anonymization

### DIFF
--- a/anonymizer/management/commands/anonymize_data.py
+++ b/anonymizer/management/commands/anonymize_data.py
@@ -4,9 +4,12 @@ anonymize_data command
 
 from __future__ import print_function
 
+import sys
 import time
 
-from django.core.management.base import AppCommand
+from django.core.management.base import AppCommand, CommandError
+from django.db import connection
+from django.utils import six
 
 from anonymizer.utils import get_anonymizers
 
@@ -18,8 +21,21 @@ class Command(AppCommand):
                             help='One or more app names.')
         parser.add_argument('--chunksize', default=2000, type=int)
         parser.add_argument('--parallel', default=4, type=int)
+        parser.add_argument('--confirmed', default=False, help='Skip confirm prompt')
 
     def handle_app_config(self, app_config, **options):
+        if not options['confirmed']:
+            self.stdout.write(
+                'This will do an in-place anonymization of "%s"' % connection.settings_dict['NAME']
+            )
+            confirm = six.moves.input('Are you sure you want to continue? [Y/N] ')
+
+            if confirm not in ('Y', 'N'):
+                raise CommandError('NOOP: Please enter "Y" or "N".')
+            if confirm == 'N':
+                self.stdout.write('Action aborted.')
+                sys.exit()
+
         chunksize = options['chunksize']
         parallel = options['parallel']
 


### PR DESCRIPTION
Since anonymizer does it in-place / is destructive, it's good to have a confirmation prompt ensuring we are anonymizing the correct DB.

@BetterWorks/engineers 
@terite 