### PR TITLE
Fixed bug checking for duplicates in unique fields

### DIFF
--- a/anonymizer/base.py
+++ b/anonymizer/base.py
@@ -64,7 +64,7 @@ class DjangoFaker(object):
 
             if retval in used:
                 raise Exception("Cannot generate unique data for field %s. Last value tried %s" % (field, retval))
-            used.add(retval)
+            self.init_values[field].add(retval)
 
         # Enforce max_length
         max_length = getattr(field, 'max_length', None)


### PR DESCRIPTION
When checking for duplicate values, the `get_allowed_values` method ensures we don't set the same values as any of the existing values. However, it doesn't check against new ones we make up since the new ones are added to the `used` set which is in local scope but should be added to the class scoped set `self.init_values[field]`